### PR TITLE
Restore checkbox pairs and validation

### DIFF
--- a/Z_FUES_ROLE_USER_TRAN
+++ b/Z_FUES_ROLE_USER_TRAN
@@ -77,6 +77,8 @@ SELECTION-SCREEN END OF BLOCK blk2.
 SELECTION-SCREEN BEGIN OF BLOCK blk3 WITH FRAME TITLE TEXT-b03.
   PARAMETERS:
     p_inact  AS CHECKBOX DEFAULT ' ',    " Include inactive users
+    p_urole  AS CHECKBOX DEFAULT 'X',    " Only users with roles
+    p_ruser  AS CHECKBOX DEFAULT 'X',    " Only roles with users
     p_rnousr AS CHECKBOX DEFAULT ' ',    " Include roles without users
     p_unorol AS CHECKBOX DEFAULT ' '.    " Include users without roles
 SELECTION-SCREEN END OF BLOCK blk3.
@@ -88,6 +90,14 @@ SELECTION-SCREEN:
     COMMENT /1(78) TEXT-c02,
     COMMENT /1(78) TEXT-c03,
   END OF BLOCK blk4.
+
+AT SELECTION-SCREEN.
+  IF p_ruser = p_rnousr.
+    MESSAGE 'Select either "Only roles with users" or "Include roles without users", not both' TYPE 'E'.
+  ENDIF.
+  IF p_urole = p_unorol.
+    MESSAGE 'Select either "Only users with roles" or "Include users without roles", not both' TYPE 'E'.
+  ENDIF.
 
 * Main Processing
 START-OF-SELECTION.
@@ -279,11 +289,11 @@ ENDFORM.
 *&      Form  APPLY_USER_ROLE_FILTERS
 *&---------------------------------------------------------------------*
 FORM apply_user_role_filters.
-  IF p_unorol = ' '.
-    DELETE gt_user_role WHERE role_name IS INITIAL OR roles_per_user = 0.
+  IF p_urole = 'X'.
+    DELETE gt_user_role WHERE user_id IS INITIAL OR roles_per_user = 0.
   ENDIF.
-  IF p_rnousr = ' '.
-    DELETE gt_user_role WHERE user_id IS INITIAL OR users_per_role = 0.
+  IF p_ruser = 'X'.
+    DELETE gt_user_role WHERE role_name IS INITIAL OR users_per_role = 0.
   ENDIF.
 ENDFORM.
 


### PR DESCRIPTION
## Summary
- restore `P_UROLE` and `P_RUSER` parameters in `Z_FUES_ROLE_USER_TRAN`
- enforce mutual exclusivity with `AT SELECTION-SCREEN`
- adjust filtering logic to use the new parameters

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888cf87e48c8332a7f8d269ef72e633