### PR TITLE
Expand report options and Spanish UI

### DIFF
--- a/Z_FUES_ROLE_USER_TRAN
+++ b/Z_FUES_ROLE_USER_TRAN
@@ -32,7 +32,26 @@ TYPES: BEGIN OF ty_transaction_auth,
          auth_object   TYPE agr_1251-object,
          auth_field    TYPE agr_1251-field,
          auth_value    TYPE agr_1251-low,
-       END OF ty_transaction_auth.
+      END OF ty_transaction_auth.
+
+* Estructura para Rol-Usuario-Transacciones
+TYPES: BEGIN OF ty_user_role_trans,
+         role_name    TYPE agr_define-agr_name,
+         user_id      TYPE xubname,
+         transaction  TYPE tcode,
+         description  TYPE tstct-ttext,
+       END OF ty_user_role_trans.
+
+* Estructura para Rol-Usuario-Transacciones-Autorizaciones
+TYPES: BEGIN OF ty_user_role_trans_auth,
+         role_name    TYPE agr_define-agr_name,
+         user_id      TYPE xubname,
+         transaction  TYPE tcode,
+         description  TYPE tstct-ttext,
+         auth_object  TYPE agr_1251-object,
+         auth_field   TYPE agr_1251-field,
+         auth_value   TYPE agr_1251-low,
+       END OF ty_user_role_trans_auth.
 
 * Structure for summary information
 TYPES: BEGIN OF ty_summary,
@@ -44,6 +63,8 @@ TYPES: BEGIN OF ty_summary,
 DATA: gt_user_role       TYPE TABLE OF ty_user_role,
       gt_role_transaction TYPE TABLE OF ty_role_transaction,
       gt_transaction_auth TYPE TABLE OF ty_transaction_auth,
+      gt_user_role_trans TYPE TABLE OF ty_user_role_trans,
+      gt_user_role_trans_auth TYPE TABLE OF ty_user_role_trans_auth,
       gt_summary          TYPE TABLE OF ty_summary,
       lo_alv              TYPE REF TO cl_salv_table.
 
@@ -61,24 +82,34 @@ SELECTION-SCREEN BEGIN OF BLOCK blk1 WITH FRAME TITLE TEXT-b01.
     SELECTION-SCREEN COMMENT 1(30) TEXT-r03 FOR FIELD rb_trans.
     PARAMETERS: rb_trans RADIOBUTTON GROUP rb1.
   SELECTION-SCREEN END OF LINE.
+  SELECTION-SCREEN BEGIN OF LINE.
+    SELECTION-SCREEN COMMENT 1(30) TEXT-r04 FOR FIELD rb_usrtrans.
+    PARAMETERS: rb_usrtrans RADIOBUTTON GROUP rb1.
+  SELECTION-SCREEN END OF LINE.
+  SELECTION-SCREEN BEGIN OF LINE.
+    SELECTION-SCREEN COMMENT 1(30) TEXT-r05 FOR FIELD rb_usrtransauth.
+    PARAMETERS: rb_usrtransauth RADIOBUTTON GROUP rb1.
+  SELECTION-SCREEN END OF LINE.
 SELECTION-SCREEN END OF BLOCK blk1.
 
 SELECTION-SCREEN BEGIN OF BLOCK blk2 WITH FRAME TITLE TEXT-b02.
   SELECT-OPTIONS:
-    s_role   FOR agr_define-agr_name,    " Role selection
-    s_user   FOR usr02-bname,            " User selection
-    s_group  FOR usr02-class,            " User group selection
-    s_tcode  FOR agr_tcodes-tcode,       " Transaction code selection
-    s_object FOR agr_1251-object,        " Authorization object selection
-    s_fdate  FOR agr_users-from_dat,     " From date selection
-    s_tdate  FOR agr_users-to_dat.       " To date selection
+    s_role   FOR agr_define-agr_name,    " Selección de roles
+    s_user   FOR usr02-bname,            " Selección de usuarios
+    s_group  FOR usr02-class,            " Selección de grupos
+    s_tcode  FOR agr_tcodes-tcode,       " Selección de transacción
+    s_object FOR agr_1251-object,        " Selección de objeto de autorización
+    s_fdate  FOR agr_users-from_dat,     " Fecha desde
+    s_tdate  FOR agr_users-to_dat.       " Fecha hasta
 SELECTION-SCREEN END OF BLOCK blk2.
 
 SELECTION-SCREEN BEGIN OF BLOCK blk3 WITH FRAME TITLE TEXT-b03.
   PARAMETERS:
-    p_inact  AS CHECKBOX DEFAULT ' ',    " Include inactive users
-    p_rnousr AS CHECKBOX DEFAULT ' ',    " Include roles without users
-    p_unorol AS CHECKBOX DEFAULT ' '.    " Include users without roles
+    p_inact  AS CHECKBOX DEFAULT ' ',    " Incluir usuarios inactivos
+    p_urole  AS CHECKBOX DEFAULT 'X',    " Solo usuarios con roles
+    p_ruser  AS CHECKBOX DEFAULT 'X',    " Solo roles con usuarios
+    p_rnousr AS CHECKBOX DEFAULT ' ',    " Incluir roles sin usuarios
+    p_unorol AS CHECKBOX DEFAULT ' '.    " Incluir usuarios sin roles
 SELECTION-SCREEN END OF BLOCK blk3.
 
 * Text Elements
@@ -89,6 +120,14 @@ SELECTION-SCREEN:
     COMMENT /1(78) TEXT-c03,
   END OF BLOCK blk4.
 
+AT SELECTION-SCREEN.
+  IF p_ruser = p_rnousr.
+    MESSAGE 'Seleccione "Solo roles con usuarios" o "Incluir roles sin usuarios", no ambos' TYPE 'E'.
+  ENDIF.
+  IF p_urole = p_unorol.
+    MESSAGE 'Seleccione "Solo usuarios con roles" o "Incluir usuarios sin roles", no ambos' TYPE 'E'.
+  ENDIF.
+
 * Main Processing
 START-OF-SELECTION.
   CASE 'X'.
@@ -98,6 +137,10 @@ START-OF-SELECTION.
       PERFORM process_role_transaction_view.
     WHEN rb_trans.
       PERFORM process_transaction_auth_view.
+    WHEN rb_usrtrans.
+      PERFORM process_user_role_trans_view.
+    WHEN rb_usrtransauth.
+      PERFORM process_user_role_trans_auth_view.
   ENDCASE.
 
 *&---------------------------------------------------------------------*
@@ -128,6 +171,22 @@ ENDFORM.
 FORM process_transaction_auth_view.
   PERFORM get_transaction_auth_data.
   PERFORM display_trans_auth_alv.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  PROCESS_USER_ROLE_TRANS_VIEW
+*&---------------------------------------------------------------------*
+FORM process_user_role_trans_view.
+  PERFORM get_user_role_trans_data.
+  PERFORM display_user_role_trans_alv.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  PROCESS_USER_ROLE_TRANS_AUTH_VIEW
+*&---------------------------------------------------------------------*
+FORM process_user_role_trans_auth_view.
+  PERFORM get_user_role_trans_auth_data.
+  PERFORM display_user_role_trans_auth_alv.
 ENDFORM.
 
 *&---------------------------------------------------------------------*
@@ -175,7 +234,7 @@ FORM get_user_role_data.
 
   gt_user_role = lt_temp.
   IF sy-subrc <> 0 AND p_rnousr = ' ' AND p_unorol = ' '.
-    MESSAGE 'No users found for the selected criteria' TYPE 'I' DISPLAY LIKE 'E'.
+    MESSAGE 'No se encontraron usuarios para los criterios seleccionados' TYPE 'I' DISPLAY LIKE 'E'.
     LEAVE LIST-PROCESSING.
   ENDIF.
 ENDFORM.
@@ -279,11 +338,11 @@ ENDFORM.
 *&      Form  APPLY_USER_ROLE_FILTERS
 *&---------------------------------------------------------------------*
 FORM apply_user_role_filters.
-  IF p_unorol = ' '.
-    DELETE gt_user_role WHERE role_name IS INITIAL OR roles_per_user = 0.
+  IF p_urole = 'X'.
+    DELETE gt_user_role WHERE user_id IS INITIAL OR roles_per_user = 0.
   ENDIF.
-  IF p_rnousr = ' '.
-    DELETE gt_user_role WHERE user_id IS INITIAL OR users_per_role = 0.
+  IF p_ruser = 'X'.
+    DELETE gt_user_role WHERE role_name IS INITIAL OR users_per_role = 0.
   ENDIF.
 ENDFORM.
 
@@ -366,12 +425,12 @@ FORM build_user_role_summary.
 
   " Build summary
   CLEAR gt_summary.
-  APPEND VALUE #( description = 'Total Users'       value = |{ lv_users }| ) TO gt_summary.
-  APPEND VALUE #( description = 'Total Roles'       value = |{ lv_roles }| ) TO gt_summary.
-  APPEND VALUE #( description = 'Inactive Users'    value = |{ lv_inactive_users }| ) TO gt_summary.
-  APPEND VALUE #( description = 'Inactive Roles'    value = |{ lv_inactive_roles }| ) TO gt_summary.
-  APPEND VALUE #( description = 'Users Without Roles' value = |{ lv_users_no_role }| ) TO gt_summary.
-  APPEND VALUE #( description = 'Roles Without Users' value = |{ lv_roles_no_user }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Usuarios Totales'         value = |{ lv_users }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Roles Totales'            value = |{ lv_roles }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Usuarios Inactivos'       value = |{ lv_inactive_users }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Roles Inactivos'          value = |{ lv_inactive_roles }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Usuarios sin Roles'       value = |{ lv_users_no_role }| ) TO gt_summary.
+  APPEND VALUE #( description = 'Roles sin Usuarios'       value = |{ lv_roles_no_user }| ) TO gt_summary.
 ENDFORM.
 
 *&---------------------------------------------------------------------*
@@ -391,8 +450,8 @@ FORM get_role_transaction_data.
     INTO TABLE @gt_role_transaction.
 
   IF sy-subrc <> 0.
-    MESSAGE 'No transactions found for the selected roles' TYPE 'I' DISPLAY LIKE 'E'.
-    LEAVE LIST-PROCESSING.
+    MESSAGE 'No se encontraron transacciones para los roles seleccionados' TYPE 'I' DISPLAY LIKE 'E'.
+  LEAVE LIST-PROCESSING.
   ENDIF.
 ENDFORM.
 
@@ -419,11 +478,64 @@ FORM get_transaction_auth_data.
     INTO TABLE @gt_transaction_auth.
 
   IF sy-subrc <> 0.
-    MESSAGE 'No authorizations found for the selected transactions' TYPE 'I' DISPLAY LIKE 'E'.
-    LEAVE LIST-PROCESSING.
+    MESSAGE 'No se encontraron autorizaciones para las transacciones seleccionadas' TYPE 'I' DISPLAY LIKE 'E'.
+  LEAVE LIST-PROCESSING.
   ENDIF.
 
   SORT gt_transaction_auth BY transaction role_name auth_object auth_field.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  GET_USER_ROLE_TRANS_DATA
+*&---------------------------------------------------------------------*
+FORM get_user_role_trans_data.
+  SELECT a~agr_name  AS role_name,
+         r~uname     AS user_id,
+         t~tcode     AS transaction,
+         s~ttext     AS description
+    FROM agr_define AS a
+    INNER JOIN agr_users AS r ON a~agr_name = r~agr_name
+    INNER JOIN agr_tcodes AS t ON a~agr_name = t~agr_name
+    LEFT JOIN tstct AS s ON t~tcode = s~tcode AND s~sprsl = @sy-langu
+    WHERE a~agr_name IN @s_role
+      AND r~uname    IN @s_user
+      AND t~tcode    IN @s_tcode
+    INTO TABLE @gt_user_role_trans.
+
+  IF sy-subrc <> 0.
+    MESSAGE 'No se encontraron transacciones para los criterios seleccionados' TYPE 'I' DISPLAY LIKE 'E'.
+    LEAVE LIST-PROCESSING.
+  ENDIF.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  GET_USER_ROLE_TRANS_AUTH_DATA
+*&---------------------------------------------------------------------*
+FORM get_user_role_trans_auth_data.
+  SELECT a~agr_name  AS role_name,
+         r~uname     AS user_id,
+         t~tcode     AS transaction,
+         s~ttext     AS description,
+         au~object   AS auth_object,
+         au~field    AS auth_field,
+         au~low      AS auth_value
+    FROM agr_define AS a
+    INNER JOIN agr_users AS r ON a~agr_name = r~agr_name
+    INNER JOIN agr_tcodes AS t ON a~agr_name = t~agr_name
+    LEFT JOIN tstct AS s ON t~tcode = s~tcode AND s~sprsl = @sy-langu
+    LEFT JOIN agr_1251 AS au ON a~agr_name = au~agr_name
+    WHERE a~agr_name IN @s_role
+      AND r~uname    IN @s_user
+      AND t~tcode    IN @s_tcode
+      AND au~object  IN @s_object
+    INTO TABLE @gt_user_role_trans_auth.
+
+  IF sy-subrc <> 0.
+    MESSAGE 'No se encontraron autorizaciones para los criterios seleccionados' TYPE 'I' DISPLAY LIKE 'E'.
+    LEAVE LIST-PROCESSING.
+  ENDIF.
+
+  SORT gt_user_role_trans_auth BY role_name user_id transaction auth_object auth_field.
 ENDFORM.
 
 *&---------------------------------------------------------------------*
@@ -442,7 +554,7 @@ FORM display_user_role_alv.
       lo_grid->create_header_information(
         row    = 1
         column = 1
-        text   = 'USER-ROLE RELATIONSHIP REPORT' ).
+        text   = 'REPORTE RELACIÓN USUARIO-ROL' ).
 
       " Add summary
       DATA: lv_row TYPE i VALUE 2.
@@ -459,16 +571,16 @@ FORM display_user_role_alv.
       lo_functions->set_all( abap_true ).
 
       " Set column headers
-      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Role' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'USER_ID' )->set_medium_text( 'User' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'USER_GROUP' )->set_medium_text( 'Group' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'FROM_DATE' )->set_medium_text( 'From Date' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'TO_DATE' )->set_medium_text( 'To Date' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'ROLE_INACTIVE' )->set_medium_text( 'Role Inactive' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'ROLES_PER_USER' )->set_medium_text( 'Roles per User' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'USERS_PER_ROLE' )->set_medium_text( 'Users per Role' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'USER_INACTIVE' )->set_medium_text( 'User Inactive' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'STATUS' )->set_medium_text( 'Status' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Rol' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USER_ID' )->set_medium_text( 'Usuario' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USER_GROUP' )->set_medium_text( 'Grupo' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'FROM_DATE' )->set_medium_text( 'Desde' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'TO_DATE' )->set_medium_text( 'Hasta' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'ROLE_INACTIVE' )->set_medium_text( 'Rol Inactivo' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'ROLES_PER_USER' )->set_medium_text( 'Roles por Usuario' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USERS_PER_ROLE' )->set_medium_text( 'Usuarios por Rol' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USER_INACTIVE' )->set_medium_text( 'Usuario Inactivo' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'STATUS' )->set_medium_text( 'Estado' ). CATCH cx_salv_not_found. ENDTRY.
 
       lo_columns->set_optimize( abap_true ).
       lo_alv->display( ).
@@ -495,7 +607,7 @@ FORM display_role_trans_alv.
       lo_grid->create_header_information(
         row    = 1
         column = 1
-        text   = 'ROLE-TRANSACTION RELATIONSHIP REPORT' ).
+        text   = 'REPORTE RELACIÓN ROL-TRANSACCIÓN' ).
       lo_alv->set_top_of_list( lo_grid ).
 
       " Configure columns
@@ -504,9 +616,9 @@ FORM display_role_trans_alv.
       lo_functions->set_all( abap_true ).
 
       " Set column headers
-      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Role Name' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transaction' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Description' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Rol' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transacción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Descripción' ). CATCH cx_salv_not_found. ENDTRY.
 
       lo_columns->set_optimize( abap_true ).
       lo_alv->display( ).
@@ -532,7 +644,7 @@ FORM display_trans_auth_alv.
       lo_grid->create_header_information(
         row    = 1
         column = 1
-        text   = 'TRANSACTION-AUTHORIZATION RELATIONSHIP REPORT' ).
+        text   = 'REPORTE TRANSACCIÓN-AUTORIZACIÓN' ).
       lo_alv->set_top_of_list( lo_grid ).
 
       " Configure columns
@@ -541,12 +653,85 @@ FORM display_trans_auth_alv.
       lo_functions->set_all( abap_true ).
 
       " Set column headers
-      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transaction' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Role/Auth' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Description' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'AUTH_OBJECT' )->set_medium_text( 'Auth Object' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'AUTH_FIELD' )->set_medium_text( 'Auth Field' ). CATCH cx_salv_not_found. ENDTRY.
-      TRY. lo_columns->get_column( 'AUTH_VALUE' )->set_medium_text( 'Auth Value' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transacción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Rol/Aut' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Descripción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_OBJECT' )->set_medium_text( 'Objeto Aut.' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_FIELD' )->set_medium_text( 'Campo Aut.' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_VALUE' )->set_medium_text( 'Valor Aut.' ). CATCH cx_salv_not_found. ENDTRY.
+
+      lo_columns->set_optimize( abap_true ).
+      lo_alv->display( ).
+
+    CATCH cx_salv_msg INTO DATA(lx_msg).
+      MESSAGE lx_msg->get_text( ) TYPE 'E'.
+  ENDTRY.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  DISPLAY_USER_ROLE_TRANS_ALV
+*&---------------------------------------------------------------------*
+FORM display_user_role_trans_alv.
+  TRY.
+      cl_salv_table=>factory(
+        IMPORTING
+          r_salv_table = lo_alv
+        CHANGING
+          t_table      = gt_user_role_trans ).
+
+      DATA(lo_grid) = NEW cl_salv_form_layout_grid( ).
+      lo_grid->create_header_information(
+        row    = 1
+        column = 1
+        text   = 'REPORTE ROL/USUARIO/TRANSACCIONES' ).
+      lo_alv->set_top_of_list( lo_grid ).
+
+      DATA(lo_columns) = lo_alv->get_columns( ).
+      DATA(lo_functions) = lo_alv->get_functions( ).
+      lo_functions->set_all( abap_true ).
+
+      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Rol' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USER_ID' )->set_medium_text( 'Usuario' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transacción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Descripción' ). CATCH cx_salv_not_found. ENDTRY.
+
+      lo_columns->set_optimize( abap_true ).
+      lo_alv->display( ).
+
+    CATCH cx_salv_msg INTO DATA(lx_msg).
+      MESSAGE lx_msg->get_text( ) TYPE 'E'.
+  ENDTRY.
+ENDFORM.
+
+*&---------------------------------------------------------------------*
+*&      Form  DISPLAY_USER_ROLE_TRANS_AUTH_ALV
+*&---------------------------------------------------------------------*
+FORM display_user_role_trans_auth_alv.
+  TRY.
+      cl_salv_table=>factory(
+        IMPORTING
+          r_salv_table = lo_alv
+        CHANGING
+          t_table      = gt_user_role_trans_auth ).
+
+      DATA(lo_grid) = NEW cl_salv_form_layout_grid( ).
+      lo_grid->create_header_information(
+        row    = 1
+        column = 1
+        text   = 'REPORTE ROL/USUARIO/TRANSACCIONES/AUTORIZACIONES' ).
+      lo_alv->set_top_of_list( lo_grid ).
+
+      DATA(lo_columns) = lo_alv->get_columns( ).
+      DATA(lo_functions) = lo_alv->get_functions( ).
+      lo_functions->set_all( abap_true ).
+
+      TRY. lo_columns->get_column( 'ROLE_NAME' )->set_medium_text( 'Rol' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'USER_ID' )->set_medium_text( 'Usuario' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'TRANSACTION' )->set_medium_text( 'Transacción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'DESCRIPTION' )->set_medium_text( 'Descripción' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_OBJECT' )->set_medium_text( 'Objeto Aut.' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_FIELD' )->set_medium_text( 'Campo Aut.' ). CATCH cx_salv_not_found. ENDTRY.
+      TRY. lo_columns->get_column( 'AUTH_VALUE' )->set_medium_text( 'Valor Aut.' ). CATCH cx_salv_not_found. ENDTRY.
 
       lo_columns->set_optimize( abap_true ).
       lo_alv->display( ).

--- a/Z_FUES_ROLE_USER_TRAN
+++ b/Z_FUES_ROLE_USER_TRAN
@@ -106,8 +106,6 @@ SELECTION-SCREEN END OF BLOCK blk2.
 SELECTION-SCREEN BEGIN OF BLOCK blk3 WITH FRAME TITLE TEXT-b03.
   PARAMETERS:
     p_inact  AS CHECKBOX DEFAULT ' ',    " Incluir usuarios inactivos
-    p_urole  AS CHECKBOX DEFAULT 'X',    " Solo usuarios con roles
-    p_ruser  AS CHECKBOX DEFAULT 'X',    " Solo roles con usuarios
     p_rnousr AS CHECKBOX DEFAULT ' ',    " Incluir roles sin usuarios
     p_unorol AS CHECKBOX DEFAULT ' '.    " Incluir usuarios sin roles
 SELECTION-SCREEN END OF BLOCK blk3.
@@ -119,14 +117,6 @@ SELECTION-SCREEN:
     COMMENT /1(78) TEXT-c02,
     COMMENT /1(78) TEXT-c03,
   END OF BLOCK blk4.
-
-AT SELECTION-SCREEN.
-  IF p_ruser = p_rnousr.
-    MESSAGE 'Seleccione "Solo roles con usuarios" o "Incluir roles sin usuarios", no ambos' TYPE 'E'.
-  ENDIF.
-  IF p_urole = p_unorol.
-    MESSAGE 'Seleccione "Solo usuarios con roles" o "Incluir usuarios sin roles", no ambos' TYPE 'E'.
-  ENDIF.
 
 * Main Processing
 START-OF-SELECTION.
@@ -338,10 +328,15 @@ ENDFORM.
 *&      Form  APPLY_USER_ROLE_FILTERS
 *&---------------------------------------------------------------------*
 FORM apply_user_role_filters.
-  IF p_urole = 'X'.
+  " Exclude usuarios sin roles cuando la opción correspondiente no esté
+  " seleccionada
+  IF p_unorol = ' '.
     DELETE gt_user_role WHERE user_id IS INITIAL OR roles_per_user = 0.
   ENDIF.
-  IF p_ruser = 'X'.
+
+  " Exclude roles sin usuarios cuando la opción correspondiente no esté
+  " seleccionada
+  IF p_rnousr = ' '.
     DELETE gt_user_role WHERE role_name IS INITIAL OR users_per_role = 0.
   ENDIF.
 ENDFORM.


### PR DESCRIPTION
## Summary
- add new structures and tables for combined role/user/transaction views
- extend selection screen with additional options in Spanish
- implement processing for new views and translate UI strings
- display updated summaries in Spanish

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888cf87e48c8332a7f8d269ef72e633