### PR TITLE
Compute FUES from authorization objects and list users without roles

### DIFF
--- a/Z_FUES_USERS_NO_ROLES.abap
+++ b/Z_FUES_USERS_NO_ROLES.abap
@@ -33,7 +33,7 @@ FORM get_users_without_roles.
     INTO TABLE @gt_users.
 
   LOOP AT gt_users ASSIGNING FIELD-SYMBOL(<fs_user>).
-    <fs_user>-fues_level = 'No disponible'.
+    <fs_user>-fues_level = 'SELF SERV'.
   ENDLOOP.
 ENDFORM.
 


### PR DESCRIPTION
## Summary
- derive FUES level from authorization object/field/value combinations and propagate to transactions, roles and users
- show FUES level in object and transaction ALVs
- add program to list users without roles including group, active flag and default SELF SERV FUES level

## Testing
- `npx -y abaplint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/abaplint)*

------
https://chatgpt.com/codex/tasks/task_e_6891162f921c8332a2193024fdd4cd83