### PR TITLE
fix: avoid index lookup on hashed table

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -1136,10 +1136,9 @@ FORM calculate_user_basic_fues.
 
   LOOP AT lt_user_obj INTO DATA(ls_obj).
     READ TABLE gt_fues_auth ASSIGNING FIELD-SYMBOL(<fs_fues>)
-         WITH KEY auth_object = ls_obj-auth_object
-                  auth_field  = ls_obj-auth_field
-                  auth_value  = ls_obj-auth_value
-         BINARY SEARCH.
+         WITH TABLE KEY auth_object = ls_obj-auth_object
+                              auth_field  = ls_obj-auth_field
+                              auth_value  = ls_obj-auth_value.
     IF sy-subrc = 0.
       READ TABLE gt_user_basic ASSIGNING FIELD-SYMBOL(<fs_user>)
            WITH KEY user_id = ls_obj-user_id.


### PR DESCRIPTION
## Summary
- avoid index operation on `gt_fues_auth` by using `WITH TABLE KEY` instead of `BINARY SEARCH`

## Testing
- `npm install -g @abaplint/cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892208e330c8332a80cd46b1e734f3e