### PR TITLE
Remove index search on hashed table

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -1136,10 +1136,9 @@ FORM calculate_user_basic_fues.
 
   LOOP AT lt_user_obj INTO DATA(ls_obj).
     READ TABLE gt_fues_auth ASSIGNING FIELD-SYMBOL(<fs_fues>)
-         WITH KEY auth_object = ls_obj-auth_object
-                  auth_field  = ls_obj-auth_field
-                  auth_value  = ls_obj-auth_value
-         BINARY SEARCH.
+         WITH TABLE KEY auth_object = ls_obj-auth_object
+                                   auth_field  = ls_obj-auth_field
+                                   auth_value  = ls_obj-auth_value.
     IF sy-subrc = 0.
       READ TABLE gt_user_basic ASSIGNING FIELD-SYMBOL(<fs_user>)
            WITH KEY user_id = ls_obj-user_id.


### PR DESCRIPTION
## Summary
- Avoid index-based search on `gt_fues_auth` hashed table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925251399483328516c3c080939d1e