### PR TITLE
Fix loop index declaration

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -1464,7 +1464,7 @@ FORM get_transaction_auth_data.
   ENDIF.
 
   IF gv_fues_enabled = abap_true AND gt_fues_auth IS NOT INITIAL.
-    LOOP AT gt_transaction_auth ASSIGNING FIELD-SYMBOL(<fs_ta>) INDEX DATA(lv_idx).
+    LOOP AT gt_transaction_auth ASSIGNING FIELD-SYMBOL(<fs_ta>) INDEX INTO DATA(lv_idx).
       READ TABLE gt_fues_auth TRANSPORTING NO FIELDS
            WITH TABLE KEY auth_object = <fs_ta>-auth_object
                            auth_field  = <fs_ta>-auth_field


### PR DESCRIPTION
## Summary
- ensure inline index variable in transaction authorization loop uses `INDEX INTO`

## Testing
- `npx --yes @abaplint/cli Z_FUES_1.abap` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68939ef70c148332bcc810d8c16c840e