### PR TITLE
Fix index handling in transaction authorization loop

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -1464,7 +1464,8 @@ FORM get_transaction_auth_data.
   ENDIF.
 
   IF gv_fues_enabled = abap_true AND gt_fues_auth IS NOT INITIAL.
-    LOOP AT gt_transaction_auth ASSIGNING FIELD-SYMBOL(<fs_ta>) INDEX INTO DATA(lv_idx).
+    DATA(lv_idx) TYPE sy-tabix.
+    LOOP AT gt_transaction_auth ASSIGNING FIELD-SYMBOL(<fs_ta>) INDEX lv_idx.
       READ TABLE gt_fues_auth TRANSPORTING NO FIELDS
            WITH TABLE KEY auth_object = <fs_ta>-auth_object
                            auth_field  = <fs_ta>-auth_field


### PR DESCRIPTION
## Summary
- replace unsupported `INDEX INTO DATA(lv_idx)` syntax with `INDEX lv_idx`
- declare `lv_idx` variable to track indices when deleting entries

## Testing
- `npx abaplint Z_FUES_1.abap` *(fails: 403 Forbidden - GET https://registry.npmjs.org/abaplint)*

------
https://chatgpt.com/codex/tasks/task_e_6893a04d89988332b4a6ff4acbf5a108