### PR TITLE
Fix SALV control creation in Z_FUES report

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -1656,7 +1656,7 @@ FORM display_user_basic_alv.
   TRY.
       cl_salv_table=>factory( IMPORTING r_salv_table = lo_alv CHANGING t_table = gt_user_basic ).
       DATA(lo_grid) = NEW cl_salv_form_layout_grid( ).
-      DATA(lo_cnt_ub) = lo_grid->add_control( row = 1 column = 1 ).
+      DATA(lo_cnt_ub) = lo_grid->create_control( row = 1 column = 1 ).
       cl_salv_table=>factory(
         EXPORTING r_container = lo_cnt_ub->get_container( )
         IMPORTING r_salv_table = DATA(lo_sum_ub)
@@ -1704,7 +1704,7 @@ FORM display_role_fues_alv.
   TRY.
       cl_salv_table=>factory( IMPORTING r_salv_table = lo_alv CHANGING t_table = gt_fues_role ).
       DATA(lo_grid) = NEW cl_salv_form_layout_grid( ).
-      DATA(lo_cnt_rf) = lo_grid->add_control( row = 1 column = 1 ).
+      DATA(lo_cnt_rf) = lo_grid->create_control( row = 1 column = 1 ).
       cl_salv_table=>factory(
         EXPORTING r_container = lo_cnt_rf->get_container( )
         IMPORTING r_salv_table = DATA(lo_sum)


### PR DESCRIPTION
## Summary
- Replace obsolete ADD_CONTROL usage with CREATE_CONTROL for SALV layout grids

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ca404e90833285a6aec1aa2468f5