### PR TITLE
Fix SALV table factory type mismatch for role data

### DIFF
--- a/Z_FUES_1.abap
+++ b/Z_FUES_1.abap
@@ -170,7 +170,7 @@ DATA: gt_user_role         TYPE STANDARD TABLE OF ty_user_role,
       gt_user_object       TYPE STANDARD TABLE OF ty_user_object,
       gt_user_profile      TYPE STANDARD TABLE OF ty_user_profile,
       gt_user_basic        TYPE STANDARD TABLE OF ty_user_basic,
-      gt_role_basic        TYPE SORTED TABLE OF ty_role_basic WITH UNIQUE KEY role_name,
+      gt_role_basic        TYPE STANDARD TABLE OF ty_role_basic WITH UNIQUE KEY role_name,
       gt_fues_tcode        TYPE SORTED TABLE  OF ty_tcode_fues WITH UNIQUE KEY transaction,
       gt_fues_auth         TYPE HASHED TABLE  OF ty_auth_fues WITH UNIQUE KEY auth_object auth_field auth_value,
       gt_fues_role         TYPE STANDARD TABLE OF ty_role_fues,
@@ -1277,7 +1277,7 @@ FORM build_role_fues_data.
     INTO TABLE @DATA(lt_roles).
 
   LOOP AT lt_roles INTO DATA(ls_role).
-    READ TABLE gt_role_basic ASSIGNING FIELD-SYMBOL(<fs_rb>) WITH TABLE KEY role_name = ls_role-role_name.
+    READ TABLE gt_role_basic ASSIGNING FIELD-SYMBOL(<fs_rb>) WITH KEY role_name = ls_role-role_name.
     IF sy-subrc <> 0.
       INSERT VALUE #( role_name = ls_role-role_name fues_level = 'No disponible' ) INTO TABLE gt_role_basic ASSIGNING <fs_rb>.
     ENDIF.
@@ -1293,7 +1293,7 @@ FORM build_role_fues_data.
   ENDIF.
 
   LOOP AT gt_fues_role INTO DATA(ls_rf).
-    READ TABLE gt_role_basic ASSIGNING <fs_rb> WITH TABLE KEY role_name = ls_rf-role_name.
+    READ TABLE gt_role_basic ASSIGNING <fs_rb> WITH KEY role_name = ls_rf-role_name.
     IF sy-subrc = 0.
       <fs_rb>-fues_level = ls_rf-fues_level.
     ELSE.
@@ -1306,7 +1306,7 @@ FORM build_role_fues_data.
     INTO TABLE @DATA(lt_all_roles).
 
   LOOP AT lt_all_roles INTO DATA(lv_role).
-    READ TABLE gt_role_basic ASSIGNING <fs_rb> WITH TABLE KEY role_name = lv_role.
+    READ TABLE gt_role_basic ASSIGNING <fs_rb> WITH KEY role_name = lv_role.
     IF sy-subrc <> 0.
       INSERT VALUE #( role_name = lv_role users_total = 0 users_active = 0 fues_level = 'No disponible' ) INTO TABLE gt_role_basic.
     ENDIF.


### PR DESCRIPTION
## Summary
- Change `gt_role_basic` to a standard table to satisfy `cl_salv_table=>factory`
- Adjust `READ TABLE` calls for standard table key access

## Testing
- `npx --yes abaplint Z_FUES_1.abap` *(fails: 403 Forbidden - GET https://registry.npmjs.org/abaplint)*

------
https://chatgpt.com/codex/tasks/task_e_6894e270ca3c83328fbe467d514b4db1